### PR TITLE
[8.0][FIX] Wrong currency amount used.

### DIFF
--- a/account_pain/wizard/payment_order_create.py
+++ b/account_pain/wizard/payment_order_create.py
@@ -146,7 +146,7 @@ class payment_order_create(orm.TransientModel):
             payment_obj.create(
                 cr, uid,
                 {'move_line_id': line.id,
-                 'amount_currency': line.amount_to_pay,
+                 'amount_currency': line.amount_residual_currency,
                  'bank_id': line2bank.get(line.id),
                  'order_id': payment.id,
                  'partner_id': line.partner_id and line.partner_id.id or False,


### PR DESCRIPTION
When creating a payment order, from imported invoices in another currency then the company invoice, the incorrect amount is taken to create the payment order.
