### PR TITLE
8.0 refactor parse info

### DIFF
--- a/l10n_be_coda_advanced/models/account_coda.py
+++ b/l10n_be_coda_advanced/models/account_coda.py
@@ -77,6 +77,7 @@ class AccountCoda(models.Model):
         wiz_vals = {
             'coda_data': self.coda_data,
             'coda_fname': self.name,
+            'coda_id': self.id,
             }
         wizard = self.env['account.coda.import'].create(wiz_vals)
         module = __name__.split('addons.')[1].split('.')[0]
@@ -90,6 +91,6 @@ class AccountCoda(models.Model):
             'res_model': wizard._name,
             'view_id': wiz_view.id,
             'target': 'new',
-            'context': dict(self._context, coda_id=self.id),
+            'context': self._context,
             'type': 'ir.actions.act_window',
             }

--- a/l10n_be_coda_advanced/wizard/coda_import.py
+++ b/l10n_be_coda_advanced/wizard/coda_import.py
@@ -64,15 +64,19 @@ class AccountCodaImport(models.TransientModel):
     note = fields.Text(string='Log')
     trans_types = fields.Many2many(
         comodel_name='account.coda.trans.type',
+        relation = 'coda_import_trans_type_rel',
         default=lambda s: s.env['account.coda.trans.type'].search([]))
     trans_codes = fields.Many2many(
         comodel_name='account.coda.trans.code',
+        relation = 'coda_import_trans_code_rel',
         default=lambda s: s.env['account.coda.trans.code'].search([]))
     trans_categs = fields.Many2many(
         comodel_name='account.coda.trans.category',
+        relation = 'coda_import_trans_categ_rel',
         default=lambda s: s.env['account.coda.trans.category'].search([]))
     comm_types = fields.Many2many(
         comodel_name='account.coda.comm.type',
+        relation = 'coda_import_comm_type_rel',
         default=lambda s: s.env['account.coda.comm.type'].search([]))
     coda_import_note = fields.Text()
     coda_import_note = fields.Text()
@@ -1212,7 +1216,6 @@ class AccountCodaImport(models.TransientModel):
 
     def _create_bank_statement_line(self, coda_statement, line):
         st_line_vals = self._prepare_st_line_vals(coda_statement, line)
-        cba = coda_statement['coda_bank_params']
         st_line = self.env['account.bank.statement.line'].create(st_line_vals)
         line['st_line_id'] = st_line.id
 

--- a/l10n_be_coda_batch/wizard/account_coda_batch_import.py
+++ b/l10n_be_coda_batch/wizard/account_coda_batch_import.py
@@ -20,6 +20,7 @@
 #
 ##############################################################################
 
+import base64
 import logging
 _logger = logging.getLogger(__name__)
 import os
@@ -134,11 +135,11 @@ class AccountCodaBatchImport(models.TransientModel):
             try:
                 wiz = coda_import_wiz.create(
                     {'batch': True,
-                     'coda_data': coda_file[1],
+                     'coda_data': base64.encodestring(coda_file[1]),
                      'coda_fname': coda_file[2],
                      'period_id': False,
                      })
-                wiz._coda_parsing()
+                wiz.coda_parsing()
                 self.log_note += _(
                     "\n\nCODA File '%s' has been imported."
                     ) % coda_file[2]


### PR DESCRIPTION
Fixing a subtle implementation flaw here. The coda parsing routine stores some info global to the parsing process on the recordset object _self_. This conflicts with the Odoo 8.0 API because the attributes are not carried over when calling self.with_context() which we want to do in our customization overrides. This change solves the problem by storing the info on some new fields on the wizard model and in one case in the context. The __skip_undefined_ attribute has been left out entirely as it was not actually set anywhere in the code to any other value than _False_.

This has a distinct consequence for the batch parsing process, as it relied on the method that the wizard model provides without actually creating the wizard instance. To store the info on the wizard instance, it needs to be created per import. This makes the distinction between the coda_parsing() and _coda_parsing() methods meaningless so they are refactored out.

This change should be considered work-in-progress as I have not actually tested batch processing yet.
