### PR TITLE
[FIX] [8.0] do not filter out top level account 

### DIFF
--- a/account_trial_balance_period_xls/report/trial_balance_period_xls.py
+++ b/account_trial_balance_period_xls/report/trial_balance_period_xls.py
@@ -193,7 +193,7 @@ class trial_balance_period_xls_parser(report_sxw.rml_parse):
                     credit = _total(i, p, 'credit')
                     period_data['debit'] = debit
                     period_data['credit'] = credit
-                    if debit or credit:
+                    if debit or credit or entry.get('top'):
                         zeros = False
                 entry['zeros'] = zeros
 


### PR DESCRIPTION
Do not filter out top level account on trial balance report generation. I believe this could occur in rare cases.